### PR TITLE
Upgrade to .NET 6

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
       "name": "run Lib",
       "type": "coreclr",
       "request": "launch",
-      "program": "${workspaceFolder}/Lib/bin/Debug/netcoreapp3.1/Lib.dll",
+      "program": "${workspaceFolder}/Lib/bin/Debug/net6.0/Lib.dll",
       "args": [],
       "cwd": "${workspaceFolder}/Lib",
       "stopAtEntry": false,
@@ -20,7 +20,7 @@
       "request": "launch",
       "preLaunchTask": "build",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/CloudFunction/bin/Debug/netcoreapp3.1/CloudFunction.dll",
+      "program": "${workspaceFolder}/CloudFunction/bin/Debug/net6.0/CloudFunction.dll",
       "args": [],
       "cwd": "${workspaceFolder}/CloudFunction",
       // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -55,7 +55,7 @@
         "--source",
         "${workspaceFolder}",
         "--runtime",
-        "dotnet3",
+        "dotnet6",
         "--trigger-http",
         "--allow-unauthenticated",
         "--set-build-env-vars=GOOGLE_BUILDABLE=CloudFunction"

--- a/CloudFunction/CloudFunction.csproj
+++ b/CloudFunction/CloudFunction.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CloudFunction/README.md
+++ b/CloudFunction/README.md
@@ -13,7 +13,7 @@ Local server will be running at http://127.0.0.1:8080
 Run in `dotNetBytes/CloudFunction/` dir
 
 ```bash
-gcloud --project dotnetbytes functions deploy parse --entry-point CloudFunction.Function --source .. --runtime dotnet3 --trigger-http --allow-unauthenticated  --set-build-env-vars=GOOGLE_BUILDABLE=CloudFunction
+gcloud --project dotnetbytes functions deploy parse --entry-point CloudFunction.Function --source .. --runtime dotnet6 --trigger-http --allow-unauthenticated  --set-build-env-vars=GOOGLE_BUILDABLE=CloudFunction
 ```
 
 Server runs at https://us-central1-dotnetbytes.cloudfunctions.net/parse

--- a/Lib/Lib.csproj
+++ b/Lib/Lib.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Changes are tested by [AppVeyor](https://ci.appveyor.com/project/darthwalsh/dotn
 
 ## Future work
 
-- [ ] Update CloudFunction to .NET 6 [recommended by GCP](https://cloud.google.com/functions/docs/concepts/dotnet-runtime)
+- [x] Update CloudFunction to .NET 6
 - [ ] Implement all [TODOs for Lib](Lib/Program.cs) and [Test](Tests/AssemblyBytesTests.cs)
 - [ ] Get `dotnet test` working on linux
   - CloudFlare [build configuration](https://developers.cloudflare.com/pages/platform/build-configuration): Installed dotnet 3.1.302	 (or dotnet6)
@@ -107,3 +107,6 @@ Changes are tested by [AppVeyor](https://ci.appveyor.com/project/darthwalsh/dotn
   - CloudFlare [Deploying "anything"](https://developers.cloudflare.com/pages/framework-guides/deploy-anything/)
   - CloudFlare [current build image OS](https://github.com/cloudflare/pages-build-image/discussions/1):  Ubuntu 16.04 (xenial) but might upgrade to 22.04 (jammy) and dotnet 6.0.5
 - MAYBE bundle as a vscode extension?
+- [ ] Update CloudFunction to [2nd gen](https://cloud.google.com/functions/docs/runtime-support#.net-core), unblocking .NET 8
+  - Also unblocks "Container Registry (used by default by Cloud Functions 1st gen for storing build artifacts) is deprecated:" https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr
+- [ ] Update CloudFunction to .NET 8 [recommended by GCP](https://cloud.google.com/functions/docs/concepts/dotnet-runtime)

--- a/Tests/AssemblyBytesTests.cs
+++ b/Tests/AssemblyBytesTests.cs
@@ -168,14 +168,14 @@ namespace Tests
       if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
         if (csc is null) {
           var lines = RunProcess("dotnet", "--list-sdks").Split('\n');
-          var v3line = lines.Single(l => l.StartsWith("3.")).Split(' ');
+          var v3line = lines.Single(l => l.StartsWith("6.")).Split(' ');
           var version = v3line[0];
           var path = v3line[1].Trim('[', ']');
           csc = Path.Join(path, version, "Roslyn", "bincore", "csc.dll");
           Console.Error.WriteLine($"Compiling with {csc}");
         }
         var refs = string.Join(' ',
-          Directory.GetFiles("/usr/local/share/dotnet/packs/Microsoft.NETCore.App.Ref/3.1.0/ref/netcoreapp3.1/", "*.dll")
+          Directory.GetFiles("/usr/local/share/dotnet/packs/Microsoft.NETCore.App.Ref/6.0.29/ref/net6.0/", "*.dll")
           .Select(dll => "/reference:" + dll));
         RunProcess("dotnet", $"{csc} {refs} {args}");
       } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
.NET Core 3 was deprecated 2024-01-30, and will be decommissioned 2025-01-30.

.NET 6 will be deprecated in a few more months, but don't switch to 2nd gen Google Cloud Functions yet.

Tested on Apple Silicon macbook:
Can dotnet run Lib.
Can vscode launch debug CloudFunction.
Ran and debugged unit tests.
Ran CloudFunction and smoke-test: POSTing DLL passed.

Appveyor CI passed.
Deployed to Google Cloud, which worked and smoke-test passed.